### PR TITLE
Add user roles and bcrypt authentication

### DIFF
--- a/client_debt_app/app.py
+++ b/client_debt_app/app.py
@@ -2,11 +2,12 @@ import os
 from datetime import datetime, date
 from functools import wraps
 from flask import Flask, render_template, request, redirect, url_for, session
-from werkzeug.security import generate_password_hash, check_password_hash
+from flask_bcrypt import Bcrypt
 from models import db, Client, Debt, Payment, User, Movement
 
 app = Flask(__name__)
 app.secret_key = os.environ.get("SECRET_KEY", "dev")
+bcrypt = Bcrypt(app)
 
 app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///" + os.path.join(app.root_path, "clients.db")
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
@@ -15,7 +16,11 @@ db.init_app(app)
 with app.app_context():
     db.create_all()
     if not User.query.first():
-        admin = User(username="admin", password_hash=generate_password_hash("admin"))
+        admin = User(
+            username="admin",
+            password_hash=bcrypt.generate_password_hash("admin").decode("utf-8"),
+            role="admin",
+        )
         db.session.add(admin)
         db.session.commit()
 
@@ -25,6 +30,17 @@ def login_required(fn):
     def wrapper(*args, **kwargs):
         if "user_id" not in session:
             return redirect(url_for("login"))
+        return fn(*args, **kwargs)
+    return wrapper
+
+
+def admin_required(fn):
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        user_id = session.get("user_id")
+        user = User.query.get(user_id)
+        if not user or user.role != "admin":
+            return redirect(url_for("index"))
         return fn(*args, **kwargs)
     return wrapper
 
@@ -39,7 +55,7 @@ def index():
 
 @app.route("/client/new", methods=["GET", "POST"])
 @login_required
-
+@admin_required
 def new_client():
     if request.method == "POST":
         name = request.form["name"]
@@ -65,7 +81,7 @@ def client_detail(client_id: int):
 
 @app.route("/client/<int:client_id>/debts", methods=["POST"])
 @login_required
-
+@admin_required
 def add_debt(client_id: int):
     client = Client.query.get_or_404(client_id)
     amount = float(request.form["amount"])
@@ -83,7 +99,7 @@ def add_debt(client_id: int):
 
 @app.route("/client/<int:client_id>/payments", methods=["POST"])
 @login_required
-
+@admin_required
 def add_payment(client_id: int):
     client = Client.query.get_or_404(client_id)
     amount = float(request.form["amount"])
@@ -103,11 +119,26 @@ def login():
         username = request.form["username"]
         password = request.form["password"]
         user = User.query.filter_by(username=username).first()
-        if user and check_password_hash(user.password_hash, password):
+        if user and bcrypt.check_password_hash(user.password_hash, password):
             session["user_id"] = user.id
             return redirect(url_for("index"))
         return render_template("login.html", error="Credenciales inválidas")
     return render_template("login.html")
+
+
+@app.route("/register", methods=["GET", "POST"])
+def register():
+    if request.method == "POST":
+        username = request.form["username"]
+        password = request.form["password"]
+        if User.query.filter_by(username=username).first():
+            return render_template("register.html", error="Usuario ya existe")
+        pw_hash = bcrypt.generate_password_hash(password).decode("utf-8")
+        user = User(username=username, password_hash=pw_hash, role="user")
+        db.session.add(user)
+        db.session.commit()
+        return redirect(url_for("login"))
+    return render_template("register.html")
 
 
 @app.route("/logout")

--- a/client_debt_app/models.py
+++ b/client_debt_app/models.py
@@ -40,6 +40,7 @@ class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
     password_hash = db.Column(db.String(128), nullable=False)
+    role = db.Column(db.String(20), nullable=False, default="user")
     movements = db.relationship("Movement", backref="user")
 
 

--- a/client_debt_app/requirements.txt
+++ b/client_debt_app/requirements.txt
@@ -1,2 +1,3 @@
 Flask==3.0.3
 Flask-SQLAlchemy==3.1.1
+Flask-Bcrypt==1.0.1

--- a/client_debt_app/templates/register.html
+++ b/client_debt_app/templates/register.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Iniciar sesión</title>
+    <title>Registrarse</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   </head>
   <body>
     <div class="container py-4" style="max-width:400px;">
-      <h1 class="mb-4">Iniciar sesión</h1>
+      <h1 class="mb-4">Registrarse</h1>
       {% if error %}
       <div class="alert alert-danger">{{ error }}</div>
       {% endif %}
@@ -21,8 +21,7 @@
           <label class="form-label">Contraseña</label>
           <input type="password" name="password" class="form-control" required>
         </div>
-        <button type="submit" class="btn btn-primary">Entrar</button>
-        <p class="mt-3">¿No tienes cuenta? <a href="{{ url_for('register') }}">Regístrate</a></p>
+        <button type="submit" class="btn btn-primary">Registrarse</button>
       </form>
     </div>
   </body>


### PR DESCRIPTION
## Summary
- add `role` field to `User` model for authorization
- secure passwords with Flask-Bcrypt and add registration route
- enforce admin-only operations with `admin_required` decorator

## Testing
- `pytest`
- `python -m py_compile client_debt_app/app.py client_debt_app/models.py`


------
https://chatgpt.com/codex/tasks/task_e_68abbd3048808329b4a5e384c90aaec3