### PR TITLE
Add pytest tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Python tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r client_debt_app/requirements.txt
+      - name: Run tests
+        run: pytest

--- a/client_debt_app/requirements.txt
+++ b/client_debt_app/requirements.txt
@@ -1,2 +1,4 @@
 Flask==3.0.3
 Flask-SQLAlchemy==3.1.1
+pytest
+pytest-env

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+pythonpath = client_debt_app
+testpaths = tests
+env =
+    SECRET_KEY=test-secret

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,23 @@
+import pytest
+from app import app, db, Client, Debt, Payment
+
+
+@pytest.fixture
+def app_context():
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        yield
+
+
+def test_total_debt(app_context):
+    client = Client(name="John Doe", document="123")
+    db.session.add(client)
+    db.session.commit()
+    debt1 = Debt(client=client, amount=100.0, description="d1")
+    debt2 = Debt(client=client, amount=50.0, description="d2")
+    payment = Payment(client=client, amount=80.0)
+    db.session.add_all([debt1, debt2, payment])
+    db.session.commit()
+    assert client.total_debt == 70.0

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,29 @@
+import pytest
+from app import app, db, User
+from werkzeug.security import generate_password_hash
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        admin = User(username="admin", password_hash=generate_password_hash("admin"))
+        db.session.add(admin)
+        db.session.commit()
+        with app.test_client() as client:
+            yield client
+
+
+def test_index_requires_login(client):
+    response = client.get("/")
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_login_success(client):
+    response = client.post(
+        "/login", data={"username": "admin", "password": "admin"}, follow_redirects=True
+    )
+    assert b"Clientes" in response.data


### PR DESCRIPTION
## Summary
- add pytest unit tests for model logic and route behavior
- configure pytest with app path and environment
- run tests in GitHub Actions on pushes and PRs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abbd3844948329bb2f26346eee20aa