### PR TITLE
Add navigation header with cash and graphs views

### DIFF
--- a/LotteryApp/LotteryApp.csproj
+++ b/LotteryApp/LotteryApp.csproj
@@ -15,5 +15,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.7" />
     <PackageReference Include="MaterialDesignThemes" Version="5.1.0" />
     <PackageReference Include="MaterialDesignColors" Version="3.1.0" />
+    <PackageReference Include="OxyPlot.Wpf" Version="2.1.0" />
   </ItemGroup>
 </Project>

--- a/LotteryApp/MainWindow.xaml
+++ b/LotteryApp/MainWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        xmlns:views="clr-namespace:LotteryApp.Views"
         mc:Ignorable="d"
         Title="Lotería - Clientes, Deudas y Pagos"
         Width="1100" Height="680"
@@ -11,10 +12,13 @@
   <Grid Margin="12">
     <Grid.RowDefinitions>
       <RowDefinition Height="Auto"/>
+      <RowDefinition Height="Auto"/>
       <RowDefinition Height="*"/>
     </Grid.RowDefinitions>
 
-    <DockPanel Grid.Row="0" LastChildFill="False" Margin="0,0,0,8">
+    <views:HeaderControl Grid.Row="0" Margin="0,0,0,8"/>
+
+    <DockPanel Grid.Row="1" LastChildFill="False" Margin="0,0,0,8">
       <TextBox x:Name="SearchBox" Width="320" materialDesign:HintAssist.Hint="Buscar cliente" Margin="0,0,8,0" KeyUp="SearchBox_KeyUp"/>
       <Button Content="Nuevo cliente" Click="NewClient_Click" Margin="0,0,8,0"/>
       <Button Content="Editar" Click="EditClient_Click" Margin="0,0,8,0"/>
@@ -22,12 +26,11 @@
       <Separator Width="12"/>
       <Button Content="Agregar deuda" Click="AddDebt_Click" Margin="0,0,8,0"/>
       <Button Content="Registrar pago" Click="AddPayment_Click" Margin="0,0,8,0"/>
-      <Button Content="Caja diaria" Click="CashDaily_Click" Margin="0,0,8,0"/>
       <Separator Width="12"/>
       <TextBlock x:Name="BalanceLabel" VerticalAlignment="Center" FontWeight="Bold"/>
     </DockPanel>
 
-    <Grid Grid.Row="1">
+    <Grid Grid.Row="2">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="3*"/>
         <ColumnDefinition Width="2*"/>

--- a/LotteryApp/MainWindow.xaml.cs
+++ b/LotteryApp/MainWindow.xaml.cs
@@ -132,12 +132,6 @@ public partial class MainWindow : Window
         }
     }
 
-    private void CashDaily_Click(object sender, RoutedEventArgs e)
-    {
-        var w = new Views.CashWindow();
-        w.ShowDialog();
-    }
-
     private void ReloadClient(int id)
     {
         LoadClients(SearchBox.Text);

--- a/LotteryApp/Views/CashWindow.xaml
+++ b/LotteryApp/Views/CashWindow.xaml
@@ -2,20 +2,24 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        xmlns:views="clr-namespace:LotteryApp.Views"
         Title="Caja diaria" Height="450" Width="700" WindowStartupLocation="CenterOwner">
   <Grid Margin="16">
     <Grid.RowDefinitions>
+      <RowDefinition Height="Auto"/>
       <RowDefinition Height="Auto"/>
       <RowDefinition Height="*"/>
       <RowDefinition Height="Auto"/>
     </Grid.RowDefinitions>
 
-    <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+    <views:HeaderControl Grid.Row="0" Margin="0,0,0,8"/>
+
+    <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,8">
       <DatePicker x:Name="DateBox" Margin="0,0,8,0" materialDesign:HintAssist.Hint="Fecha" SelectedDateChanged="DateBox_SelectedDateChanged"/>
       <Button Content="Retirar efectivo" Click="Withdraw_Click"/>
     </StackPanel>
 
-    <Grid Grid.Row="1">
+    <Grid Grid.Row="2">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="*"/>
@@ -41,6 +45,6 @@
       </GroupBox>
     </Grid>
 
-    <TextBlock Grid.Row="2" x:Name="TotalLabel" FontWeight="Bold" HorizontalAlignment="Right"/>
+    <TextBlock Grid.Row="3" x:Name="TotalLabel" FontWeight="Bold" HorizontalAlignment="Right"/>
   </Grid>
 </Window>

--- a/LotteryApp/Views/DebtsWindow.xaml
+++ b/LotteryApp/Views/DebtsWindow.xaml
@@ -1,0 +1,22 @@
+<Window x:Class="LotteryApp.Views.DebtsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:views="clr-namespace:LotteryApp.Views"
+        Title="Deudas" Height="450" Width="700" WindowStartupLocation="CenterOwner">
+  <Grid Margin="16">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto"/>
+      <RowDefinition Height="*"/>
+    </Grid.RowDefinitions>
+    <views:HeaderControl Grid.Row="0" Margin="0,0,0,8"/>
+    <DataGrid Grid.Row="1" x:Name="DebtsGrid" AutoGenerateColumns="False" IsReadOnly="True">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="Fecha" Binding="{Binding Date, StringFormat=d}" Width="120"/>
+        <DataGridTextColumn Header="Cliente" Binding="{Binding Client.Name}" Width="*"/>
+        <DataGridTextColumn Header="Monto" Binding="{Binding Amount, StringFormat=C}" Width="120"/>
+        <DataGridTextColumn Header="Detalle" Binding="{Binding Description}" Width="200"/>
+      </DataGrid.Columns>
+    </DataGrid>
+  </Grid>
+</Window>
+

--- a/LotteryApp/Views/DebtsWindow.xaml.cs
+++ b/LotteryApp/Views/DebtsWindow.xaml.cs
@@ -1,0 +1,27 @@
+using System.Linq;
+using System.Windows;
+using LotteryApp.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace LotteryApp.Views;
+
+public partial class DebtsWindow : Window
+{
+    private readonly AppDbContext _db = new();
+
+    public DebtsWindow()
+    {
+        InitializeComponent();
+        DebtsGrid.ItemsSource = _db.Debts
+            .Include(d => d.Client)
+            .OrderByDescending(d => d.Date)
+            .ToList();
+    }
+
+    protected override void OnClosed(System.EventArgs e)
+    {
+        _db.Dispose();
+        base.OnClosed(e);
+    }
+}
+

--- a/LotteryApp/Views/GraphsWindow.xaml
+++ b/LotteryApp/Views/GraphsWindow.xaml
@@ -1,0 +1,16 @@
+<Window x:Class="LotteryApp.Views.GraphsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:views="clr-namespace:LotteryApp.Views"
+        xmlns:oxy="http://oxyplot.org/wpf"
+        Title="Gráficos" Height="450" Width="700" WindowStartupLocation="CenterOwner">
+  <Grid Margin="16">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto"/>
+      <RowDefinition Height="*"/>
+    </Grid.RowDefinitions>
+    <views:HeaderControl Grid.Row="0" Margin="0,0,0,8"/>
+    <oxy:PlotView x:Name="Plot" Grid.Row="1"/>
+  </Grid>
+</Window>
+

--- a/LotteryApp/Views/GraphsWindow.xaml.cs
+++ b/LotteryApp/Views/GraphsWindow.xaml.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using System.Windows;
+using LotteryApp.Data;
+using OxyPlot;
+using OxyPlot.Axes;
+using OxyPlot.Series;
+
+namespace LotteryApp.Views;
+
+public partial class GraphsWindow : Window
+{
+    private readonly AppDbContext _db = new();
+
+    public GraphsWindow()
+    {
+        InitializeComponent();
+        LoadChart();
+    }
+
+    private void LoadChart()
+    {
+        var model = new PlotModel { Title = "Saldo por cliente" };
+        var series = new ColumnSeries();
+        var clients = _db.Clients.ToList();
+        for (int i = 0; i < clients.Count; i++)
+        {
+            series.Items.Add(new ColumnItem((double)clients[i].Balance));
+        }
+        model.Series.Add(series);
+        model.Axes.Add(new CategoryAxis { Position = AxisPosition.Bottom, ItemsSource = clients, LabelField = nameof(Models.Client.Name) });
+        Plot.Model = model;
+    }
+
+    protected override void OnClosed(System.EventArgs e)
+    {
+        _db.Dispose();
+        base.OnClosed(e);
+    }
+}
+

--- a/LotteryApp/Views/HeaderControl.xaml
+++ b/LotteryApp/Views/HeaderControl.xaml
@@ -1,0 +1,11 @@
+<UserControl x:Class="LotteryApp.Views.HeaderControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <DockPanel LastChildFill="False">
+    <Button Content="Clientes" Click="Clients_Click" Margin="0,0,8,0"/>
+    <Button Content="Deudas" Click="Debts_Click" Margin="0,0,8,0"/>
+    <Button Content="Caja" Click="Cash_Click" Margin="0,0,8,0"/>
+    <Button Content="Gráficos" Click="Graphs_Click"/>
+  </DockPanel>
+</UserControl>
+

--- a/LotteryApp/Views/HeaderControl.xaml.cs
+++ b/LotteryApp/Views/HeaderControl.xaml.cs
@@ -1,0 +1,42 @@
+using System.Windows;
+using System.Windows.Controls;
+using LotteryApp;
+
+namespace LotteryApp.Views;
+
+public partial class HeaderControl : UserControl
+{
+    public HeaderControl()
+    {
+        InitializeComponent();
+    }
+
+    private void Clients_Click(object sender, RoutedEventArgs e)
+    {
+        var w = new MainWindow();
+        w.Show();
+        Window.GetWindow(this)?.Close();
+    }
+
+    private void Debts_Click(object sender, RoutedEventArgs e)
+    {
+        var w = new DebtsWindow();
+        w.Show();
+        Window.GetWindow(this)?.Close();
+    }
+
+    private void Cash_Click(object sender, RoutedEventArgs e)
+    {
+        var w = new CashWindow();
+        w.Show();
+        Window.GetWindow(this)?.Close();
+    }
+
+    private void Graphs_Click(object sender, RoutedEventArgs e)
+    {
+        var w = new GraphsWindow();
+        w.Show();
+        Window.GetWindow(this)?.Close();
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add reusable header to navigate between clients, debts, cash and graphs sections
- Implement debts listing view and graphs view with OxyPlot chart
- Integrate header into main and cash windows for consistent navigation

## Testing
- `dotnet build LotteryApp/LotteryApp.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68add858e640832983e1d5097a13329c