### PR TITLE
Track payment methods and daily cash flow

### DIFF
--- a/client_debt_app/forms.py
+++ b/client_debt_app/forms.py
@@ -1,5 +1,12 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, PasswordField, FloatField, DateField, SubmitField
+from wtforms import (
+    StringField,
+    PasswordField,
+    FloatField,
+    DateField,
+    SubmitField,
+    SelectField,
+)
 from wtforms.validators import DataRequired, Length, NumberRange
 
 
@@ -25,4 +32,19 @@ class DebtForm(FlaskForm):
 class PaymentForm(FlaskForm):
     date = DateField("Fecha", validators=[DataRequired()], format="%Y-%m-%d")
     amount = FloatField("Monto", validators=[DataRequired(), NumberRange(min=0)])
+    method = SelectField(
+        "Método",
+        choices=[
+            ("cash", "Efectivo"),
+            ("transfer", "Transferencia"),
+            ("other", "Otros"),
+        ],
+        validators=[DataRequired()],
+    )
     submit = SubmitField("Agregar pago")
+
+
+class WithdrawalForm(FlaskForm):
+    amount = FloatField("Monto", validators=[DataRequired(), NumberRange(min=0)])
+    description = StringField("Descripción", validators=[Length(max=200)])
+    submit = SubmitField("Retirar")

--- a/client_debt_app/models.py
+++ b/client_debt_app/models.py
@@ -34,6 +34,15 @@ class Payment(db.Model):
     client_id = db.Column(db.Integer, db.ForeignKey("client.id"), nullable=False)
     date = db.Column(db.Date, nullable=False, default=date.today)
     amount = db.Column(db.Float, nullable=False)
+    method = db.Column(db.String(20), nullable=False, default="cash")
+
+    @property
+    def method_label(self) -> str:
+        return {
+            "cash": "Efectivo",
+            "transfer": "Transferencia",
+            "other": "Otros",
+        }.get(self.method, self.method)
 
 
 class User(db.Model):

--- a/client_debt_app/templates/cash.html
+++ b/client_debt_app/templates/cash.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Caja diaria</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  </head>
+  <body>
+    <div class="container py-4">
+      <h1 class="mb-4">Caja diaria</h1>
+      <form method="get" class="mb-4">
+        <div class="input-group" style="max-width: 300px;">
+          <input type="date" name="date" class="form-control" value="{{ date.strftime('%Y-%m-%d') }}">
+          <button class="btn btn-primary" type="submit">Cambiar</button>
+        </div>
+      </form>
+
+      <h2>Pagos</h2>
+      <table class="table table-bordered">
+        <thead>
+          <tr>
+            <th>Cliente</th>
+            <th>Fecha</th>
+            <th>Monto</th>
+            <th>Método</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for p in payments %}
+          <tr>
+            <td>{{ p.client.name }}</td>
+            <td>{{ p.date.strftime('%d/%m/%Y') }}</td>
+            <td>${{ '%.2f'|format(p.amount) }}</td>
+            <td>{{ p.method_label }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <div class="mb-4"><strong>Total efectivo:</strong> ${{ '%.2f'|format(total_cash) }}</div>
+
+      <h2>Retiros</h2>
+      <table class="table table-bordered">
+        <thead>
+          <tr>
+            <th>Fecha</th>
+            <th>Monto</th>
+            <th>Descripción</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for w in withdrawals %}
+          <tr>
+            <td>{{ w.timestamp.strftime('%d/%m/%Y %H:%M') }}</td>
+            <td>${{ '%.2f'|format(w.amount) }}</td>
+            <td>{{ w.description or '' }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <div class="mb-4"><strong>Total retiros:</strong> ${{ '%.2f'|format(total_withdrawals) }}</div>
+
+      <h3>Retirar efectivo</h3>
+      <form method="post" class="row g-3 mb-4">
+        {{ form.csrf_token }}
+        <div class="col-md-4">
+          {{ form.amount.label(class="form-label") }}
+          {{ form.amount(class="form-control", step="0.01") }}
+        </div>
+        <div class="col-md-6">
+          {{ form.description.label(class="form-label") }}
+          {{ form.description(class="form-control") }}
+        </div>
+        <div class="col-12">
+          {{ form.submit(class="btn btn-warning") }}
+        </div>
+      </form>
+
+      <div class="mb-4"><strong>Total en caja:</strong> ${{ '%.2f'|format(cash_total) }}</div>
+
+      <a href="{{ url_for('index') }}" class="btn btn-secondary">Volver</a>
+    </div>
+  </body>
+</html>

--- a/client_debt_app/templates/client_detail.html
+++ b/client_debt_app/templates/client_detail.html
@@ -60,6 +60,7 @@
           <tr>
             <th>Fecha</th>
             <th>Monto</th>
+            <th>Método</th>
           </tr>
         </thead>
         <tbody>
@@ -67,6 +68,7 @@
           <tr>
             <td>{{ p.date.strftime('%d/%m/%Y') }}</td>
             <td>${{ '%.2f'|format(p.amount) }}</td>
+            <td>{{ p.method_label }}</td>
           </tr>
           {% endfor %}
         </tbody>
@@ -82,6 +84,10 @@
         <div class="col-md-4">
           {{ payment_form.amount.label(class="form-label") }}
           {{ payment_form.amount(class="form-control", step="0.01") }}
+        </div>
+        <div class="col-md-4">
+          {{ payment_form.method.label(class="form-label") }}
+          {{ payment_form.method(class="form-select") }}
         </div>
         <div class="col-12">
           {{ payment_form.submit(class="btn btn-success") }}

--- a/client_debt_app/templates/clients.html
+++ b/client_debt_app/templates/clients.html
@@ -10,7 +10,10 @@
     <div class="container py-4">
       <div class="d-flex justify-content-between mb-4">
         <h1 class="m-0">Clientes</h1>
-        <a href="{{ url_for('logout') }}" class="btn btn-outline-secondary">Salir</a>
+        <div>
+          <a href="{{ url_for('cash') }}" class="btn btn-outline-primary">Caja</a>
+          <a href="{{ url_for('logout') }}" class="btn btn-outline-secondary">Salir</a>
+        </div>
       </div>
       <a href="{{ url_for('new_client') }}" class="btn btn-primary mb-3">Nuevo cliente</a>
 


### PR DESCRIPTION
## Summary
- Allow specifying payment method and store it with each payment
- Add daily cash page to sum cash payments and register withdrawals
- Link to cash summary from client list

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68addb5de0a08329a70727766f01fd2d