### PR TITLE
Fix TemplateSyntaxError in clients template

### DIFF
--- a/client_debt_app/templates/clients.html
+++ b/client_debt_app/templates/clients.html
@@ -42,4 +42,6 @@
       {% endfor %}
     </tbody>
   </table>
-{% endblock %}
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Remove stray `endblock` tag from `clients.html`
- Add missing closing tags to complete HTML structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ade17e09c083299876c0950030e9a5