### PR TITLE
Enable creating debts from list view and track cash income

### DIFF
--- a/client_debt_app/forms.py
+++ b/client_debt_app/forms.py
@@ -29,6 +29,14 @@ class DebtForm(FlaskForm):
     submit = SubmitField("Agregar deuda")
 
 
+class DebtClientForm(FlaskForm):
+    client_id = SelectField("Cliente", coerce=int, validators=[DataRequired()])
+    date = DateField("Fecha", validators=[DataRequired()], format="%Y-%m-%d")
+    amount = FloatField("Monto", validators=[DataRequired(), NumberRange(min=0)])
+    description = StringField("Descripción", validators=[DataRequired(), Length(max=200)])
+    submit = SubmitField("Agregar deuda")
+
+
 class PaymentForm(FlaskForm):
     date = DateField("Fecha", validators=[DataRequired()], format="%Y-%m-%d")
     amount = FloatField("Monto", validators=[DataRequired(), NumberRange(min=0)])
@@ -48,3 +56,9 @@ class WithdrawalForm(FlaskForm):
     amount = FloatField("Monto", validators=[DataRequired(), NumberRange(min=0)])
     description = StringField("Descripción", validators=[Length(max=200)])
     submit = SubmitField("Retirar")
+
+
+class IncomeForm(FlaskForm):
+    amount = FloatField("Monto", validators=[DataRequired(), NumberRange(min=0)])
+    description = StringField("Descripción", validators=[Length(max=200)])
+    submit = SubmitField("Ingresar")

--- a/client_debt_app/templates/cash.html
+++ b/client_debt_app/templates/cash.html
@@ -30,7 +30,28 @@
       {% endfor %}
     </tbody>
   </table>
-  <div class="mb-4 font-semibold">Total efectivo: ${{ '%.2f'|format(total_cash) }}</div>
+  <div class="mb-4 font-semibold">Total efectivo: ${{ '%.2f'|format(total_payments) }}</div>
+
+  <h2 class="text-xl font-semibold mb-2">Ingresos</h2>
+  <table class="min-w-full bg-white mb-4">
+    <thead>
+      <tr class="border-b">
+        <th class="text-left py-2 px-3">Fecha</th>
+        <th class="text-left py-2 px-3">Monto</th>
+        <th class="text-left py-2 px-3">Descripción</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for i in incomes %}
+      <tr class="border-b">
+        <td class="py-2 px-3">{{ i.timestamp.strftime('%d/%m/%Y %H:%M') }}</td>
+        <td class="py-2 px-3">${{ '%.2f'|format(i.amount) }}</td>
+        <td class="py-2 px-3">{{ i.description or '' }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <div class="mb-4 font-semibold">Total ingresos: ${{ '%.2f'|format(total_incomes) }}</div>
 
   <h2 class="text-xl font-semibold mb-2">Retiros</h2>
   <table class="min-w-full bg-white mb-4">
@@ -53,19 +74,35 @@
   </table>
   <div class="mb-4 font-semibold">Total retiros: ${{ '%.2f'|format(total_withdrawals) }}</div>
 
-  <h3 class="text-lg font-semibold mb-2">Retirar efectivo</h3>
+  <h3 class="text-lg font-semibold mb-2">Ingresar efectivo</h3>
   <form method="post" class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-    {{ form.csrf_token }}
+    {{ income_form.csrf_token }}
     <div>
-      {{ form.amount.label(class="block mb-1") }}
-      {{ form.amount(class="border rounded w-full px-3 py-2", step="0.01") }}
+      {{ income_form.amount.label(class="block mb-1") }}
+      {{ income_form.amount(class="border rounded w-full px-3 py-2", step="0.01") }}
     </div>
     <div class="md:col-span-2">
-      {{ form.description.label(class="block mb-1") }}
-      {{ form.description(class="border rounded w-full px-3 py-2") }}
+      {{ income_form.description.label(class="block mb-1") }}
+      {{ income_form.description(class="border rounded w-full px-3 py-2") }}
     </div>
     <div class="md:col-span-3">
-      {{ form.submit(class="bg-yellow-500 text-white px-4 py-2 rounded") }}
+      {{ income_form.submit(class="bg-green-500 text-white px-4 py-2 rounded") }}
+    </div>
+  </form>
+
+  <h3 class="text-lg font-semibold mb-2">Retirar efectivo</h3>
+  <form method="post" class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+    {{ withdraw_form.csrf_token }}
+    <div>
+      {{ withdraw_form.amount.label(class="block mb-1") }}
+      {{ withdraw_form.amount(class="border rounded w-full px-3 py-2", step="0.01") }}
+    </div>
+    <div class="md:col-span-2">
+      {{ withdraw_form.description.label(class="block mb-1") }}
+      {{ withdraw_form.description(class="border rounded w-full px-3 py-2") }}
+    </div>
+    <div class="md:col-span-3">
+      {{ withdraw_form.submit(class="bg-yellow-500 text-white px-4 py-2 rounded") }}
     </div>
   </form>
 

--- a/client_debt_app/templates/debts.html
+++ b/client_debt_app/templates/debts.html
@@ -2,6 +2,7 @@
 {% block title %}Deudas{% endblock %}
 {% block content %}
   <h1 class="text-2xl font-bold mb-4">Deudas</h1>
+  <a href="{{ url_for('new_debt') }}" class="inline-block bg-blue-500 text-white px-4 py-2 rounded mb-4">Nueva deuda</a>
   <table class="min-w-full bg-white">
     <thead>
       <tr class="border-b">

--- a/client_debt_app/templates/new_debt.html
+++ b/client_debt_app/templates/new_debt.html
@@ -1,0 +1,28 @@
+{% extends 'layout.html' %}
+{% block title %}Nueva deuda{% endblock %}
+{% block content %}
+  <h1 class="text-2xl font-bold mb-4">Nueva deuda</h1>
+  <form method="post" class="grid gap-4 max-w-md">
+    {{ form.csrf_token }}
+    <div>
+      {{ form.client_id.label(class="block mb-1") }}
+      {{ form.client_id(class="border rounded w-full px-3 py-2") }}
+    </div>
+    <div>
+      {{ form.date.label(class="block mb-1") }}
+      {{ form.date(class="border rounded w-full px-3 py-2") }}
+    </div>
+    <div>
+      {{ form.amount.label(class="block mb-1") }}
+      {{ form.amount(class="border rounded w-full px-3 py-2", step="0.01") }}
+    </div>
+    <div>
+      {{ form.description.label(class="block mb-1") }}
+      {{ form.description(class="border rounded w-full px-3 py-2") }}
+    </div>
+    <div>
+      {{ form.submit(class="bg-blue-500 text-white px-4 py-2 rounded") }}
+    </div>
+  </form>
+  <a href="{{ url_for('debts') }}" class="inline-block mt-4 bg-gray-500 text-white px-4 py-2 rounded">Volver</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow administrators to create a debt from the debts page selecting a client
- show and record cash income movements alongside withdrawals in daily cash view

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ade79538308329beaf1f0b64bd2f1d