### PR TITLE
Restrict cash income to admins and track movement users

### DIFF
--- a/client_debt_app/templates/cash.html
+++ b/client_debt_app/templates/cash.html
@@ -74,6 +74,7 @@
   </table>
   <div class="mb-4 font-semibold">Total retiros: ${{ '%.2f'|format(total_withdrawals) }}</div>
 
+  {% if is_admin %}
   <h3 class="text-lg font-semibold mb-2">Ingresar efectivo</h3>
   <form method="post" class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
     {{ income_form.csrf_token }}
@@ -89,6 +90,7 @@
       {{ income_form.submit(class="bg-green-500 text-white px-4 py-2 rounded") }}
     </div>
   </form>
+  {% endif %}
 
   <h3 class="text-lg font-semibold mb-2">Retirar efectivo</h3>
   <form method="post" class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">


### PR DESCRIPTION
## Summary
- Ensure database tables include `role` and `user_id` columns for user roles and movement ownership
- Limit cash income actions to admin users and record the acting user on withdrawals and deposits
- Hide cash income form from non-admin users in the UI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae0533949c8329b834ffe2796d9438